### PR TITLE
remap more old quality fields to new ones

### DIFF
--- a/qualities.py
+++ b/qualities.py
@@ -30,21 +30,27 @@ def extract_qualities(xmlroot):
         name_id = name_remap.get(name_id, name_id)
 
         fields_map = {
-                'speed_print':  'print_speed',
-                'speed_travel': 'travel_speed',
-                'speed_infill': 'infill_speed',
+                'speed_print':      'print_speed',
+                'speed_travel':     'travel_speed',
+                'speed_infill':     'infill_speed',
+                'speed_layer_0':    'bottom_layer_speed',
+                'top_thickness':    'solid_layer_thickness',
+                'bottom_thickness': 'solid_layer_thickness',
+                'speed_wall_0':     'inset0_speed',
+                'speed_wall_x':     'insetx_speed',
         }
         values_fields = (
                 ('layer_height',        float),
-                #solid_layer_thickness                  -> TODO
+                ('top_thickness',       float),         # solid_layer_thickness
+                ('bottom_thickness',    float),         # solid_layer_thickness
                 ('wall_thickness',      float),
                 ('speed_print',         int),           # print_speed
                 #temp_preci                             -> TODO
                 ('speed_travel',        int),           # travel_speed
-                #bottom_layer_speed                     -> TODO
+                ('speed_layer_0',       int),           # bottom_layer_speed
                 ('speed_infill',        int),           # infill_speed
-                #inset0_speed                           -> TODO
-                #insetx_speed                           -> TODO
+                ('speed_wall_0',        int),           # inset0_speed
+                ('speed_wall_x',        int),           # insetx_speed
         )
 
         values = {}


### PR DESCRIPTION
Remap have been calculated based on LegacyProfileReader plugin one
(https://github.com/Ultimaker/Cura/blob/d391639b48e3e3adc3af6c935e7595490ed4025a/plugins/LegacyProfileReader/DictionaryOfDoom.json)

The LegacyProfileReader use more complex rules than 1 to 1 mapping. I've considered that complex rules can be simplified to 1-1 given other Dagoma settings.

Here are the rules applied:

bottom_layer_speed -> speed_layer_0

solid_layer_thickness -> bottom_thickness // Should be 0 if solid_bottom is False, but it is set to True in Config_Expert
solid_layer_thickness -> top_thickness // Should be 0 if solid_top is False, but it is set to True in Config_Expert

inset0_speed -> speed_wall_0 // Should be print_speed if speed_wall_0 is 0
insetx_speed -> speed_wall_x // Should be print_speed if speed_wall_x is 0